### PR TITLE
feat: add unit display in tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ title: Activity
 | `valueMode`       | string   | `clamp_zero` | `clamp_zero` (negatives = 0) or `range` (levels span min..max)    |
 | `missingMode`     | string   | `zero`       | `zero` (missing = 0) or `transparent` (missing days are distinct) |
 | `show_legend`     | boolean  | `true`       | Show the Less/More legend                                         |
+| `unit`            | string   | —            | Unit to display in tooltip (auto-detects from entity if not set)  |
 
 > **Note:** When using `valueMode: range` or diverging colors, `missingMode` is automatically set to `transparent` because zero has meaning within the range.
 

--- a/plugin/config.ts
+++ b/plugin/config.ts
@@ -177,6 +177,7 @@ const HeatmapConfigSchema = v.pipe(
     missingMode: v.optional(MissingModeSchema, CONFIG_DEFAULTS.missingMode),
     valueMode: v.optional(ValueModeSchema, CONFIG_DEFAULTS.valueMode),
     baseColor: v.optional(BaseColorSchema, CONFIG_DEFAULTS.baseColor),
+    unit: v.optional(v.string()),
     backgroundColor: v.optional(v.string()),
 
     // Diverging color scheme (both required for diverging mode)

--- a/plugin/zen-ui.ts
+++ b/plugin/zen-ui.ts
@@ -429,6 +429,15 @@ export class ZenUI extends LitElement {
     })
   }
 
+  private _getUnit(): string | undefined {
+    if (!this._config) return undefined
+    // Config unit takes precedence over auto-detected unit
+    if (this._config.unit) return this._config.unit
+    // Auto-detect from entity's unit_of_measurement attribute
+    const stateObj = this.hass?.states[this._config.entity]
+    return stateObj?.attributes?.unit_of_measurement as string | undefined
+  }
+
   render() {
     if (!this._config) return html``
 
@@ -509,7 +518,7 @@ export class ZenUI extends LitElement {
               <div class="tooltip-count">
                 ${this._tooltip.missing
                   ? t('missing', this._getLocale())
-                  : this._tooltip.count.toFixed(2)}
+                  : `${this._tooltip.count.toFixed(2)}${this._getUnit() ? ` ${this._getUnit()}` : ''}`}
               </div>
             </div>
           `

--- a/web/demo.html
+++ b/web/demo.html
@@ -243,12 +243,14 @@
             state: 'on',
             attributes: {
               data: [],
+              unit_of_measurement: 'kWh',
             },
           },
           'sensor.temperature_delta': {
             state: 'on',
             attributes: {
               data: [],
+              unit_of_measurement: '°C',
             },
           },
           'sensor.score': {


### PR DESCRIPTION
## Summary
- Auto-detects unit from entity's `unit_of_measurement` attribute
- Adds optional `unit` config option for manual override
- Updates demo with `unit_of_measurement` on energy and temperature sensors

Closes #13

## Test plan
- [ ] Run `pnpm dev` and open demo
- [ ] Hover over Energy Balance card - tooltip shows `kWh`
- [ ] Hover over Temperature Variance card - tooltip shows `°C`
- [ ] Test explicit `unit` config overrides auto-detect

🤖 Generated with [Claude Code](https://claude.com/claude-code)