### PR TITLE
feat: add weekday labels configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ title: Activity
 | `levelCount`      | number   | `5`          | Number of intensity levels (2-10)                                 |
 | `levelThresholds` | number[] | —            | Custom percentage boundaries for levels (see below)               |
 | `weekStartDay`    | string   | `monday`     | First day of week: `monday`, `mon`, `sunday`, or `sun`            |
+| `weekdayLabels`   | string   | `short`      | Weekday label display: `none`, `short`, `all`, or `letter`        |
 | `valueMode`       | string   | `clamp_zero` | `clamp_zero` (negatives = 0) or `range` (levels span min..max)    |
 | `missingMode`     | string   | `zero`       | `zero` (missing = 0) or `transparent` (missing days are distinct) |
 | `show_legend`     | boolean  | `true`       | Show the Less/More legend                                         |
@@ -255,6 +256,23 @@ card: heatmap
 entity: sensor.habits
 title: Habit Tracker
 weekStartDay: sunday
+```
+
+**Weekday Labels**
+
+Control how weekday labels are displayed:
+
+- `short` (default): Show 3 alternating labels (Mon/Wed/Fri or Tue/Thu/Sat)
+- `none`: Hide all weekday labels for a cleaner look
+- `all`: Show all 7 days with short names
+- `letter`: Show single-letter abbreviations for all 7 days (M, T, W...)
+
+```yaml
+type: custom:zen-ui
+card: heatmap
+entity: sensor.habits
+title: Habit Tracker
+weekdayLabels: letter # Single letters (M, T, W...)
 ```
 
 **Sparse Data with Transparent Missing Days**

--- a/plugin/cards/heatmap/render.test.ts
+++ b/plugin/cards/heatmap/render.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import { getDayLabel, generateDayLabels } from './render'
+
+describe('getDayLabel', () => {
+  it('returns short weekday names for short mode', () => {
+    // Using 'en' locale for predictable results
+    expect(getDayLabel(0, 'en', 'short')).toBe('Sun')
+    expect(getDayLabel(1, 'en', 'short')).toBe('Mon')
+    expect(getDayLabel(2, 'en', 'short')).toBe('Tue')
+    expect(getDayLabel(3, 'en', 'short')).toBe('Wed')
+    expect(getDayLabel(4, 'en', 'short')).toBe('Thu')
+    expect(getDayLabel(5, 'en', 'short')).toBe('Fri')
+    expect(getDayLabel(6, 'en', 'short')).toBe('Sat')
+  })
+
+  it('returns short weekday names for all mode', () => {
+    expect(getDayLabel(0, 'en', 'all')).toBe('Sun')
+    expect(getDayLabel(1, 'en', 'all')).toBe('Mon')
+  })
+
+  it('returns single letter for letter mode', () => {
+    // Note: 'narrow' format returns single letter in most locales
+    expect(getDayLabel(0, 'en', 'letter')).toBe('S')
+    expect(getDayLabel(1, 'en', 'letter')).toBe('M')
+    expect(getDayLabel(2, 'en', 'letter')).toBe('T')
+    expect(getDayLabel(3, 'en', 'letter')).toBe('W')
+    expect(getDayLabel(4, 'en', 'letter')).toBe('T')
+    expect(getDayLabel(5, 'en', 'letter')).toBe('F')
+    expect(getDayLabel(6, 'en', 'letter')).toBe('S')
+  })
+
+  it('respects locale for short mode', () => {
+    // German locale
+    expect(getDayLabel(0, 'de', 'short')).toBe('So')
+    expect(getDayLabel(1, 'de', 'short')).toBe('Mo')
+  })
+
+  it('respects locale for letter mode', () => {
+    // German locale
+    expect(getDayLabel(0, 'de', 'letter')).toBe('S')
+    expect(getDayLabel(1, 'de', 'letter')).toBe('M')
+  })
+})
+
+describe('generateDayLabels', () => {
+  describe('mode: none', () => {
+    it('returns empty array', () => {
+      expect(generateDayLabels('none', 0, 'en')).toEqual([])
+      expect(generateDayLabels('none', 1, 'en')).toEqual([])
+    })
+  })
+
+  describe('mode: short', () => {
+    it('shows 3 alternating labels when week starts Sunday', () => {
+      const labels = generateDayLabels('short', 0, 'en')
+
+      expect(labels).toHaveLength(3)
+      expect(labels[0]).toEqual({ row: 1, label: 'Mon' })
+      expect(labels[1]).toEqual({ row: 3, label: 'Wed' })
+      expect(labels[2]).toEqual({ row: 5, label: 'Fri' })
+    })
+
+    it('shows 3 alternating labels when week starts Monday', () => {
+      const labels = generateDayLabels('short', 1, 'en')
+
+      expect(labels).toHaveLength(3)
+      expect(labels[0]).toEqual({ row: 1, label: 'Tue' })
+      expect(labels[1]).toEqual({ row: 3, label: 'Thu' })
+      expect(labels[2]).toEqual({ row: 5, label: 'Sat' })
+    })
+  })
+
+  describe('mode: all', () => {
+    it('shows all 7 days with short names (Sunday start)', () => {
+      const labels = generateDayLabels('all', 0, 'en')
+
+      expect(labels).toHaveLength(7)
+      expect(labels[0]).toEqual({ row: 0, label: 'Sun' })
+      expect(labels[1]).toEqual({ row: 1, label: 'Mon' })
+      expect(labels[2]).toEqual({ row: 2, label: 'Tue' })
+      expect(labels[3]).toEqual({ row: 3, label: 'Wed' })
+      expect(labels[4]).toEqual({ row: 4, label: 'Thu' })
+      expect(labels[5]).toEqual({ row: 5, label: 'Fri' })
+      expect(labels[6]).toEqual({ row: 6, label: 'Sat' })
+    })
+
+    it('shows all 7 days respecting Monday start order', () => {
+      const labels = generateDayLabels('all', 1, 'en')
+
+      expect(labels).toHaveLength(7)
+      expect(labels[0]).toEqual({ row: 0, label: 'Mon' })
+      expect(labels[1]).toEqual({ row: 1, label: 'Tue' })
+      expect(labels[2]).toEqual({ row: 2, label: 'Wed' })
+      expect(labels[3]).toEqual({ row: 3, label: 'Thu' })
+      expect(labels[4]).toEqual({ row: 4, label: 'Fri' })
+      expect(labels[5]).toEqual({ row: 5, label: 'Sat' })
+      expect(labels[6]).toEqual({ row: 6, label: 'Sun' })
+    })
+  })
+
+  describe('mode: letter', () => {
+    it('shows all 7 days with single letters (Sunday start)', () => {
+      const labels = generateDayLabels('letter', 0, 'en')
+
+      expect(labels).toHaveLength(7)
+      expect(labels[0]).toEqual({ row: 0, label: 'S' })
+      expect(labels[1]).toEqual({ row: 1, label: 'M' })
+      expect(labels[2]).toEqual({ row: 2, label: 'T' })
+      expect(labels[3]).toEqual({ row: 3, label: 'W' })
+      expect(labels[4]).toEqual({ row: 4, label: 'T' })
+      expect(labels[5]).toEqual({ row: 5, label: 'F' })
+      expect(labels[6]).toEqual({ row: 6, label: 'S' })
+    })
+
+    it('shows all 7 days with single letters (Monday start)', () => {
+      const labels = generateDayLabels('letter', 1, 'en')
+
+      expect(labels).toHaveLength(7)
+      expect(labels[0]).toEqual({ row: 0, label: 'M' })
+      expect(labels[1]).toEqual({ row: 1, label: 'T' })
+      expect(labels[2]).toEqual({ row: 2, label: 'W' })
+      expect(labels[3]).toEqual({ row: 3, label: 'T' })
+      expect(labels[4]).toEqual({ row: 4, label: 'F' })
+      expect(labels[5]).toEqual({ row: 5, label: 'S' })
+      expect(labels[6]).toEqual({ row: 6, label: 'S' })
+    })
+
+    it('respects locale for letter format', () => {
+      const labels = generateDayLabels('letter', 1, 'de')
+
+      expect(labels).toHaveLength(7)
+      expect(labels[0]).toEqual({ row: 0, label: 'M' })
+      expect(labels[6]).toEqual({ row: 6, label: 'S' })
+    })
+  })
+})

--- a/plugin/cards/heatmap/render.ts
+++ b/plugin/cards/heatmap/render.ts
@@ -7,6 +7,7 @@
 import { html, svg, type TemplateResult } from 'lit'
 import type { HeatmapData } from '../../data-pipeline'
 import type { CardRenderContext } from '../types'
+import type { WeekdayLabelsMode } from '../../config'
 import { calculateGridPositions } from './grid'
 import { t } from '../../shared/localize'
 import { parseYmdDate } from '../../shared/date'
@@ -16,6 +17,62 @@ const GAP = 3
 const STEP = RECT_SIZE + GAP
 const X_START = 30
 const Y_START = 20
+
+export interface DayLabel {
+  row: number
+  label: string
+}
+
+/**
+ * Gets the localized day label for a given day index.
+ * dayIndex: 0=Sun, 1=Mon, 2=Tue, 3=Wed, 4=Thu, 5=Fri, 6=Sat
+ */
+export function getDayLabel(
+  dayIndex: number,
+  locale: string,
+  mode: WeekdayLabelsMode,
+): string {
+  // Jan 2, 2000 = Sunday, so dayIndex 0=Sun, 1=Mon, etc.
+  const d = new Date(Date.UTC(2000, 0, 2 + dayIndex))
+  const weekdayFormat = mode === 'letter' ? 'narrow' : 'short'
+  return d.toLocaleString(locale, {
+    weekday: weekdayFormat,
+    timeZone: 'UTC',
+  })
+}
+
+/**
+ * Generates day labels based on the weekday labels mode and week start day.
+ * weekStart: 0=Sunday, 1=Monday
+ */
+export function generateDayLabels(
+  mode: WeekdayLabelsMode,
+  weekStart: 0 | 1,
+  locale: string,
+): DayLabel[] {
+  if (mode === 'none') return []
+
+  if (mode === 'all' || mode === 'letter') {
+    // Show all 7 days
+    return [0, 1, 2, 3, 4, 5, 6].map((row) => ({
+      row,
+      label: getDayLabel((row + weekStart) % 7, locale, mode),
+    }))
+  }
+
+  // Default 'short' - alternating labels (every other day starting from row 1)
+  return weekStart === 0
+    ? [
+        { row: 1, label: getDayLabel(1, locale, mode) }, // Mon
+        { row: 3, label: getDayLabel(3, locale, mode) }, // Wed
+        { row: 5, label: getDayLabel(5, locale, mode) }, // Fri
+      ]
+    : [
+        { row: 1, label: getDayLabel(2, locale, mode) }, // Tue
+        { row: 3, label: getDayLabel(4, locale, mode) }, // Thu
+        { row: 5, label: getDayLabel(6, locale, mode) }, // Sat
+      ]
+}
 
 export function renderYearGraph(
   heatmapData: HeatmapData,
@@ -70,28 +127,11 @@ export function renderYearGraph(
   const width = heatmapData.weeks.length * STEP - GAP
   const height = 7 * STEP - GAP
 
-  // Day labels based on week start day (using UTC to avoid DST issues)
-  const getDayLabel = (dayIndex: number): string => {
-    // Jan 2, 2000 = Sunday, so dayIndex 0=Sun, 1=Mon, etc.
-    const d = new Date(Date.UTC(2000, 0, 2 + dayIndex))
-    return d.toLocaleString(context.locale, {
-      weekday: 'short',
-      timeZone: 'UTC',
-    })
-  }
-
-  const dayLabels =
-    weekStart === 0
-      ? [
-          { row: 1, label: getDayLabel(1) }, // Mon
-          { row: 3, label: getDayLabel(3) }, // Wed
-          { row: 5, label: getDayLabel(5) }, // Fri
-        ]
-      : [
-          { row: 1, label: getDayLabel(2) }, // Tue
-          { row: 3, label: getDayLabel(4) }, // Thu
-          { row: 5, label: getDayLabel(6) }, // Sat
-        ]
+  const dayLabels = generateDayLabels(
+    context.config.weekdayLabels,
+    weekStart,
+    context.locale,
+  )
 
   const yearLabel = heatmapData.range.label || ''
 

--- a/plugin/config.test.ts
+++ b/plugin/config.test.ts
@@ -55,6 +55,7 @@ describe('validateConfig', () => {
       expect(config.range).toBe(CONFIG_DEFAULTS.range)
       expect(config.years).toBe(CONFIG_DEFAULTS.years)
       expect(config.weekStartDay).toBe(CONFIG_DEFAULTS.weekStartDay)
+      expect(config.weekdayLabels).toBe(CONFIG_DEFAULTS.weekdayLabels)
       expect(config.levelCount).toBe(CONFIG_DEFAULTS.levelCount)
       expect(config.baseColor).toBe(CONFIG_DEFAULTS.baseColor)
       expect(config.show_legend).toBe(CONFIG_DEFAULTS.show_legend)
@@ -216,6 +217,39 @@ describe('validateConfig', () => {
       expect(
         validateConfig(validConfig({ baseColor: '#12345' })).baseColor,
       ).toBe('#40c463')
+    })
+  })
+
+  describe('weekdayLabels validation', () => {
+    it('accepts valid weekdayLabels values', () => {
+      expect(
+        validateConfig(validConfig({ weekdayLabels: 'none' })).weekdayLabels,
+      ).toBe('none')
+      expect(
+        validateConfig(validConfig({ weekdayLabels: 'short' })).weekdayLabels,
+      ).toBe('short')
+      expect(
+        validateConfig(validConfig({ weekdayLabels: 'all' })).weekdayLabels,
+      ).toBe('all')
+      expect(
+        validateConfig(validConfig({ weekdayLabels: 'letter' })).weekdayLabels,
+      ).toBe('letter')
+    })
+
+    it('defaults to short', () => {
+      expect(validateConfig(validConfig()).weekdayLabels).toBe('short')
+    })
+
+    it('falls back to default for invalid weekdayLabels', () => {
+      expect(
+        validateConfig(validConfig({ weekdayLabels: 'invalid' })).weekdayLabels,
+      ).toBe('short')
+      expect(
+        validateConfig(validConfig({ weekdayLabels: 123 })).weekdayLabels,
+      ).toBe('short')
+      expect(
+        validateConfig(validConfig({ weekdayLabels: '' })).weekdayLabels,
+      ).toBe('short')
     })
   })
 

--- a/plugin/config.ts
+++ b/plugin/config.ts
@@ -12,6 +12,9 @@ import { HEX_COLOR_REGEX } from './color-utils'
 // Week start day type
 export type WeekStartDay = 'sunday' | 'monday'
 
+// Weekday labels mode type
+export type WeekdayLabelsMode = 'none' | 'short' | 'all' | 'letter'
+
 // Card type - extend as new types are added
 export type CardType = 'heatmap'
 
@@ -26,6 +29,7 @@ export const CONFIG_DEFAULTS = {
   range: 'rolling' as const,
   years: 1,
   weekStartDay: 'monday' as WeekStartDay,
+  weekdayLabels: 'short' as WeekdayLabelsMode,
   levelCount: 5,
   baseColor: '#40c463',
   show_legend: true,
@@ -110,6 +114,12 @@ const ValueModeSchema = withFallback(
   CONFIG_DEFAULTS.valueMode,
 )
 
+// Schema for weekdayLabels
+const WeekdayLabelsSchema = withFallback(
+  v.picklist(['none', 'short', 'all', 'letter']),
+  CONFIG_DEFAULTS.weekdayLabels,
+)
+
 // Schema for baseColor (hex color with fallback)
 const BaseColorSchema = v.pipe(
   v.unknown(),
@@ -172,6 +182,10 @@ const HeatmapConfigSchema = v.pipe(
     years: v.optional(YearsSchema, CONFIG_DEFAULTS.years),
     end_date: v.optional(v.string()),
     weekStartDay: v.optional(WeekStartDaySchema, CONFIG_DEFAULTS.weekStartDay),
+    weekdayLabels: v.optional(
+      WeekdayLabelsSchema,
+      CONFIG_DEFAULTS.weekdayLabels,
+    ),
     levelCount: v.optional(LevelCountSchema, CONFIG_DEFAULTS.levelCount),
     levelThresholds: v.optional(v.array(v.number())),
     missingMode: v.optional(MissingModeSchema, CONFIG_DEFAULTS.missingMode),

--- a/web/demo.html
+++ b/web/demo.html
@@ -139,6 +139,12 @@
         <option value="es">Spanish (Español)</option>
         <option value="ja">Japanese (unsupported)</option>
       </select>
+      <select id="weekday-labels-select">
+        <option value="short">Weekday: Short (default)</option>
+        <option value="none">Weekday: None</option>
+        <option value="all">Weekday: All</option>
+        <option value="letter">Weekday: Letter</option>
+      </select>
     </div>
 
     <div class="demo-container">
@@ -217,6 +223,9 @@
       const themeBtn = document.getElementById('theme-toggle')
       const regenBtn = document.getElementById('regen-data')
       const localeSelect = document.getElementById('locale-select')
+      const weekdayLabelsSelect = document.getElementById(
+        'weekday-labels-select',
+      )
 
       // Mock Hass Object
       let mockHass = {
@@ -554,6 +563,37 @@
       localeSelect.addEventListener('change', (e) => {
         mockHass.locale.language = e.target.value
         updateAllCards()
+      })
+
+      weekdayLabelsSelect.addEventListener('change', (e) => {
+        const value = e.target.value
+        // Update all configs
+        rollingConfig.weekdayLabels = value
+        multiyearConfig.weekdayLabels = value
+        binaryConfig.weekdayLabels = value
+        themedConfig.weekdayLabels = value
+        missingConfig.weekdayLabels = value
+        negativeConfig.weekdayLabels = value
+        divergingConfig.weekdayLabels = value
+        divergingCustomConfig.weekdayLabels = value
+        // Re-set all cards
+        cardRolling.setConfig({ ...rollingConfig })
+        cardMultiyear.setConfig({ ...multiyearConfig })
+        cardBinary.setConfig({ ...binaryConfig })
+        cardThemed.setConfig({ ...themedConfig })
+        cardMissing.setConfig({ ...missingConfig })
+        cardNegative.setConfig({ ...negativeConfig })
+        cardDiverging.setConfig({ ...divergingConfig })
+        cardDivergingCustom.setConfig({ ...divergingCustomConfig })
+        // Update displayed configs
+        configRolling.textContent = toYaml(rollingConfig)
+        configMultiyear.textContent = toYaml(multiyearConfig)
+        configBinary.textContent = toYaml(binaryConfig)
+        configThemed.textContent = toYaml(themedConfig)
+        configMissing.textContent = toYaml(missingConfig)
+        configNegative.textContent = toYaml(negativeConfig)
+        configDiverging.textContent = toYaml(divergingConfig)
+        configDivergingCustom.textContent = toYaml(divergingCustomConfig)
       })
     </script>
   </body>


### PR DESCRIPTION
## Summary

- Add `weekdayLabels` config option to control weekday label display
- Four modes: `none`, `short` (default), `all`, `letter`
- Labels automatically localized based on user locale
- Extracted `getDayLabel` and `generateDayLabels` functions for testability

## Changes

- `plugin/config.ts` - Added `WeekdayLabelsMode` type and schema
- `plugin/cards/heatmap/render.ts` - Extracted label generation logic
- `plugin/cards/heatmap/render.test.ts` - New test file (13 tests)
- `plugin/config.test.ts` - Added validation tests
- `web/demo.html` - Added weekday labels selector
- `README.md` - Documented the new option

## Test plan

- [x] All 255 tests passing
- [x] Build succeeds
- [x] Lint clean
- [ ] Manual test in demo page with all 4 modes
- [ ] Test with different locales

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)