### PR TITLE
fix: add inline rx/ry attributes for Firefox compatibility

### DIFF
--- a/plugin/cards/heatmap/render.ts
+++ b/plugin/cards/heatmap/render.ts
@@ -153,6 +153,8 @@ export function renderYearGraph(
                   height="${RECT_SIZE}"
                   x="${col * STEP}"
                   y="${row * STEP}"
+                  rx="2"
+                  ry="2"
                   fill="${color}"
                   style="cursor: pointer;"
                   @mouseenter=${(e: MouseEvent) => context.onCellMouseEnter(e, day.date, day.count, day.missing)}


### PR DESCRIPTION
## Summary
- Adds inline `rx="2"` and `ry="2"` attributes to SVG rect elements
- Firefox doesn't support `rx`/`ry` as CSS properties with `shape-rendering: geometricPrecision`
- Ensures consistent rounded corners across all browsers

Fixes #21

## Test plan
- [ ] Verify rounded corners display correctly in Firefox
- [ ] Verify no regression in Chrome/Edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)