### PR TITLE
Update documentation URL for Zen UI plugin

### DIFF
--- a/plugin/zen-ui.ts
+++ b/plugin/zen-ui.ts
@@ -51,7 +51,7 @@ window.customCards.push({
   name: 'Zen UI',
   description: 'GitHub-style contribution heatmap for tracking daily metrics',
   preview: true,
-  documentationURL: 'https://github.com/stormari/zen-ui',
+  documentationURL: 'https://github.com/shashanktomar/zen-ui',
 })
 
 @customElement('zen-ui')


### PR DESCRIPTION
Small correction of the help button when configuring the card. URL seem to have been changed everywhere but here from stormari to shashanktomar.
